### PR TITLE
Fix pink path colors on Linux/Mac

### DIFF
--- a/Source/PathAvoidGrid.cs
+++ b/Source/PathAvoidGrid.cs
@@ -39,7 +39,7 @@ namespace PathAvoid
 
             public Color GetCellExtraColor(int index)
             {
-                return this.color;
+                return Color.white;
             }
         }
 


### PR DESCRIPTION
CellBoolDrawer requires giver.GetCellExtraColor (index) to be white to generate a texture, otherwise pink happens because it tries to draw an empty texture. I don't understand why it doesn't happen under Windows.